### PR TITLE
Enable image format option in settings.py

### DIFF
--- a/annotator/tasks.py
+++ b/annotator/tasks.py
@@ -149,7 +149,7 @@ def create_cache_task(video_id):
 
 @shared_task
 def extract_frames(video_id):
-    img_ext = 'png'
+    img_ext = settings.IMAGE_FORMAT
     
     video = Video.objects.get(id=video_id)
     files = video.uploadfile_set.filter(file_type=UploadFile.VIDEO)

--- a/annotator/views.py
+++ b/annotator/views.py
@@ -239,7 +239,7 @@ class UploadVideos(View):
                 'size': file.file.size,
                 # 'deleteUrl': reverse('delete_file', args=(file.id,)),
                 'deleteType': 'POST',
-                'type': 'image/png'
+                'type': 'image/%s' % (settings.IMAGE_FORMAT)
             })
 
         response_data = {

--- a/eva/settings.py
+++ b/eva/settings.py
@@ -44,6 +44,8 @@ ALLOWED_HOSTS = ["*"]
 
 MAX_ZIPFILES = 10
 
+IMAGE_FORMAT = 'png' # Choose output type either png or jpeg
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Added an option to choose JPEG or PNG (default png) for the image frames.  Users may prefer to choose JPEG images instead of PNG in order to save disk space