### PR TITLE
Only set bounds when annotation is visible.

### DIFF
--- a/annotator/static/player.js
+++ b/annotator/static/player.js
@@ -390,11 +390,16 @@ class Player {
          we want to hide if:
             - the very first frame object is in the future (nextIndex == 0 && closestIndex is null)
             - we're after the last frame and that last frame was marked as continueInterpolation false */
-        rect.appear({
+        var appear_params = {
             real: closestIndex != null,
             selected: this.selectedAnnotation === annotation && !rect.locked,
             singlekeyframe: continueInterpolation && !(nextIndex == 0 && closestIndex === null)
-        });
+        }
+
+        rect.appear(appear_params);
+
+        //only set bounds when annotation is visible.
+        if (!appear_params.real) return;
 
         // Don't mess up our drag
         if (rect.isBeingDragged()) return;


### PR DESCRIPTION
the set bounds function is actually kinda cpu intensive. I noticed that
when there are thousands of bounding boxes in your video sequence, it can add
seconds to moving bounding boxes, creating bounding boxes, and switching to
another image frame. reduces the ammount of times set bounds is called
by  only calling the function when annotations are set to appear
visibile.

This is the time it used to take to draw annotations for a video with a few hundred bounding boxes
![image](https://user-images.githubusercontent.com/918633/87478566-d8dd1300-c5de-11ea-8f0d-7905f28d8ae0.png)

this is the time it takes to draw annotations after.
![image](https://user-images.githubusercontent.com/918633/87478637-f7430e80-c5de-11ea-9f68-99d9c92d3b05.png)
