### PR TITLE
moved llvm dep to dockerfile from requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY requirements.txt /app/
 RUN pip install --upgrade pip \
+  && pip install llvmlite==0.31.0 \
   && pip install --no-cache-dir -r requirements.txt \
   && pip install --no-cache-dir gunicorn psycopg2-binary
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ opencv-contrib-python>=4.1,<4.1.0.26
 numpy>=1.16.4,<1.16.5
 numba>=0.44.1,<0.44.2
 pyyaml>=5.1.1,<5.1.2
-llvmlite==0.32.1


### PR DESCRIPTION
This is the error I got with master.
```
Building wheels for collected packages: pyyaml, llvmlite, billiard
  Building wheel for pyyaml (setup.py): started
  Building wheel for pyyaml (setup.py): finished with status 'done'
  Created wheel for pyyaml: filename=PyYAML-5.1.1-cp35-cp35m-linux_x86_64.whl size=44099 sha256=6910885e795232c730ba00ac21d1beb580bdeb6e7a7d410996ffe9865eed512b
  Stored in directory: /tmp/pip-ephem-wheel-cache-p6phjqb_/wheels/35/d7/98/5a685658fce1a1311772d65acd2a200130dece3727d7ad4917
  Building wheel for llvmlite (setup.py): started
  Building wheel for llvmlite (setup.py): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/local/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0tthw3z5/llvmlite/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0tthw3z5/llvmlite/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-o55xl3_g
       cwd: /tmp/pip-install-0tthw3z5/llvmlite/
  Complete output (26 lines):
  running bdist_wheel
  /usr/local/bin/python /tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py
  LLVM version... Traceback (most recent call last):
    File "/tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py", line 106, in main_posix
      out = subprocess.check_output([llvm_config, '--version'])
    File "/usr/local/lib/python3.5/subprocess.py", line 316, in check_output
      **kwargs).stdout
    File "/usr/local/lib/python3.5/subprocess.py", line 383, in run
      with Popen(*popenargs, **kwargs) as process:
    File "/usr/local/lib/python3.5/subprocess.py", line 676, in __init__
      restore_signals, start_new_session)
    File "/usr/local/lib/python3.5/subprocess.py", line 1289, in _execute_child
      raise child_exception_type(errno_num, err_msg)
  FileNotFoundError: [Errno 2] No such file or directory: 'llvm-config'
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py", line 192, in <module>
      main()
    File "/tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py", line 182, in main
      main_posix('linux', '.so')
    File "/tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py", line 109, in main_posix
      "to the path for llvm-config" % (llvm_config,))
  RuntimeError: llvm-config failed executing, please point LLVM_CONFIG to the path for llvm-config
  error: command '/usr/local/bin/python' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for llvmlite
  Running setup.py clean for llvmlite
  Building wheel for billiard (setup.py): started
  Building wheel for billiard (setup.py): finished with status 'done'
  Created wheel for billiard: filename=billiard-3.5.0.5-py3-none-any.whl size=87880 sha256=8f3d81c5ccea61892dc6c2c9db61b7fd001933d28920ec62b32d1dbe8c2e9ae0
  Stored in directory: /tmp/pip-ephem-wheel-cache-p6phjqb_/wheels/81/e1/91/25cf46d0af7e69eb9bc48833ead16e042d86560209e661d378
Successfully built pyyaml billiard
Failed to build llvmlite
DEPRECATION: Could not build wheels for llvmlite which do not use PEP 517. pip will fall back to legacy 'setup.py install' for these. pip 21.0 will remove support for this functionality. A possible replacement is to fix the wheel build issue reported above. You can find discussion regarding this at https://github.com/pypa/pip/issues/8368.
Installing collected packages: pytz, Django, billiard, vine, amqp, kombu, redis, celery, numpy, six, h5py, opencv-python-headless, opencv-contrib-python, llvmlite, numba, pyyaml
    Running setup.py install for llvmlite: started
    Running setup.py install for llvmlite: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0tthw3z5/llvmlite/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0tthw3z5/llvmlite/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-re8nvak2/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.5m/llvmlite
         cwd: /tmp/pip-install-0tthw3z5/llvmlite/
    Complete output (29 lines):
    running install
    running build
    got version from file /tmp/pip-install-0tthw3z5/llvmlite/llvmlite/_version.py {'version': '0.32.1', 'full': 'aa11b129c0b55973067422397821ae6d44fa5e70'}
    running build_ext
    /usr/local/bin/python /tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py
    LLVM version... Traceback (most recent call last):
      File "/tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py", line 106, in main_posix
        out = subprocess.check_output([llvm_config, '--version'])
      File "/usr/local/lib/python3.5/subprocess.py", line 316, in check_output
        **kwargs).stdout
      File "/usr/local/lib/python3.5/subprocess.py", line 383, in run
        with Popen(*popenargs, **kwargs) as process:
      File "/usr/local/lib/python3.5/subprocess.py", line 676, in __init__
        restore_signals, start_new_session)
      File "/usr/local/lib/python3.5/subprocess.py", line 1289, in _execute_child
        raise child_exception_type(errno_num, err_msg)
    FileNotFoundError: [Errno 2] No such file or directory: 'llvm-config'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py", line 192, in <module>
        main()
      File "/tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py", line 182, in main
        main_posix('linux', '.so')
      File "/tmp/pip-install-0tthw3z5/llvmlite/ffi/build.py", line 109, in main_posix
        "to the path for llvm-config" % (llvm_config,))
    RuntimeError: llvm-config failed executing, please point LLVM_CONFIG to the path for llvm-config
    error: command '/usr/local/bin/python' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /usr/local/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0tthw3z5/llvmlite/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0tthw3z5/llvmlite/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-re8nvak2/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.5m/llvmlite Check the logs for full command output.
ERROR: Service 'celery' failed to build: The command '/bin/sh -c pip install --upgrade pip   && pip install --no-cache-dir -r requirements.txt   && pip install --no-cache-dir gunicorn psycopg2-binary' returned a non-zero code: 1


```